### PR TITLE
Add dependent delete

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,4 +1,4 @@
 class Trip < ApplicationRecord
   belongs_to :user
-  has_many :activities
+  has_many :activities, :dependent => :delete_all
 end


### PR DESCRIPTION
In the trips model, added dependent delete all. This deletes all related
activities when you delete a trip.